### PR TITLE
Feat: add an option to use default instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ metadata:
   namespace: default
 spec:
   selector:
-    app: kubetrigger-sample
+    instance: kubetrigger-sample
   triggers:
     - k8s-resource-watcher:
         apiVersion: "v1"

--- a/api/v1alpha1/triggerservice_types.go
+++ b/api/v1alpha1/triggerservice_types.go
@@ -28,9 +28,9 @@ import (
 type TriggerServiceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	//+optional
 	Selector map[string]string `json:"selector"`
 	// Config for kube-trigger
-	//+optional
 	//+kubebuilder:object:generate=true
 	Triggers []config.TriggerMetaWrapper `json:"triggers"`
 }

--- a/config/crd/standard.oam.dev_triggerservices.yaml
+++ b/config/crd/standard.oam.dev_triggerservices.yaml
@@ -124,7 +124,7 @@ spec:
                   type: object
                 type: array
             required:
-            - selector
+            - triggers
             type: object
           status:
             description: TriggerServiceStatus defines the observed state of TriggerService.

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - /manager
           args:
             - --leader-elect
+            - --create-default-instance
+            - --service-use-default-instance
           image: oamdev/kube-trigger-manager:latest
           imagePullPolicy: IfNotPresent
           name: manager

--- a/config/samples/standard_v1alpha1_triggerinstance.yaml
+++ b/config/samples/standard_v1alpha1_triggerinstance.yaml
@@ -4,5 +4,5 @@ metadata:
   name: kubetrigger-sample
   namespace: default
   labels:
-    app: kubetrigger-sample
+    instance: kubetrigger-sample
 spec:

--- a/config/samples/standard_v1alpha1_triggerservice.yaml
+++ b/config/samples/standard_v1alpha1_triggerservice.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kubetrigger-sample-config
   namespace: default
 spec:
+  # If you ignore selectors, you can use the default TriggerInstance,
+  # given the related options are enabled using manager args.
   selector:
     instance: kubetrigger-sample
   triggers:

--- a/config/samples/standard_v1alpha1_triggerservice.yaml
+++ b/config/samples/standard_v1alpha1_triggerservice.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   selector:
-    app: kubetrigger-sample
+    instance: kubetrigger-sample
   triggers:
     - k8s-resource-watcher:
         apiVersion: "v1"

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+// Config contains options for controllers.
+type Config struct {
+	// CreateDefaultInstance will make the controller always create a default TriggerInstance.
+	CreateDefaultInstance bool
+	// ServiceUseDefaultInstance will make TriggerService use the default TriggerInstance if spec.selector is empty.
+	ServiceUseDefaultInstance bool
+}

--- a/controllers/triggerinstance/triggerinstance_controller.go
+++ b/controllers/triggerinstance/triggerinstance_controller.go
@@ -18,11 +18,15 @@ package triggerinstance
 
 import (
 	"context"
+	"time"
 
 	standardv1alpha1 "github.com/kubevela/kube-trigger/api/v1alpha1"
+	"github.com/kubevela/kube-trigger/controllers/config"
+	"github.com/kubevela/kube-trigger/pkg/util"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,10 +36,20 @@ type Reconciler struct {
 	client.Client
 	StatusWriter client.StatusWriter
 	Scheme       *runtime.Scheme
+	Config       config.Config
 }
 
 var (
 	logger = logrus.WithField("controller", "kube-trigger")
+	// defaultInstanceLastCreatedTime is used to make sure the existence of default instance is not constantly checked.
+	defaultInstanceLastCreatedTime = time.Time{}
+)
+
+const (
+	DefaultInstanceName                       = "default"
+	DefaultInstanceNamespace                  = "kube-trigger-system"
+	InstanceNameLabel                         = "instance"
+	MinIntervalBetweenCheckingDefaultInstance = 5
 )
 
 //+kubebuilder:rbac:groups=standard.oam.dev,resources=kubetriggers,verbs=get;list;watch;create;update;patch;delete
@@ -71,27 +85,87 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}()
 
-	if err := r.ReconcileClusterRoleBinding(ctx, &ki, req); err != nil {
-		logger.Errorf("reconcile ClusterRoleBinding failed: %s", err)
+	// Create relevant resource of ki.
+	err := r.createRelevantResources(ctx, &ki, req)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := r.ReconcileServiceAccount(ctx, &ki, req); err != nil {
-		logger.Errorf("reconcile ServiceAccount failed: %s", err)
-		return ctrl.Result{}, err
-	}
-
-	if err := r.ReconcileConfigMap(ctx, &ki, req); err != nil {
-		logger.Errorf("reconcile ServiceAccount failed: %s", err)
-		return ctrl.Result{}, err
-	}
-
-	if err := r.ReconcileDeployment(ctx, &ki, req); err != nil {
-		logger.Errorf("reconcile Deployment failed: %s", err)
-		return ctrl.Result{}, err
+	if r.Config.CreateDefaultInstance {
+		r.createDefaultInstance(ctx)
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) createRelevantResources(
+	ctx context.Context,
+	ki *standardv1alpha1.TriggerInstance,
+	req ctrl.Request,
+) error {
+	if err := r.ReconcileClusterRoleBinding(ctx, ki, req); err != nil {
+		logger.Errorf("reconcile ClusterRoleBinding failed: %s", err)
+		return err
+	}
+
+	if err := r.ReconcileServiceAccount(ctx, ki, req); err != nil {
+		logger.Errorf("reconcile ServiceAccount failed: %s", err)
+		return err
+	}
+
+	if err := r.ReconcileConfigMap(ctx, ki, req); err != nil {
+		logger.Errorf("reconcile ServiceAccount failed: %s", err)
+		return err
+	}
+
+	if err := r.ReconcileDeployment(ctx, ki, req); err != nil {
+		logger.Errorf("reconcile Deployment failed: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+func (r *Reconciler) createDefaultInstance(ctx context.Context) {
+	// Only proceed if it is at least 5s after the last run to prevent constant re-runs
+	// and the default instance is unlikely to fail.
+	if !time.Now().Add(time.Second * time.Duration(MinIntervalBetweenCheckingDefaultInstance)).
+		After(defaultInstanceLastCreatedTime) {
+		return
+	}
+	// Record the time this run whether the rest logic is successful or not.
+	defaultInstanceLastCreatedTime = time.Now()
+
+	defaultInstance := standardv1alpha1.TriggerInstance{}
+	err := r.Get(ctx, types.NamespacedName{
+		Namespace: DefaultInstanceNamespace,
+		Name:      DefaultInstanceName,
+	}, &defaultInstance)
+	if err == nil {
+		return
+	}
+	if util.IgnoreNotFound(err) != nil {
+		logger.Errorf("getting default instance failed, the default TriggerInstance may not be created: %s", err)
+		return
+	}
+
+	// Default instance not found, create a default one.
+	// TODO(charlie0129): also check if it is healthy, if not, fix it.
+	defaultInstance.Namespace = DefaultInstanceNamespace
+	defaultInstance.Name = DefaultInstanceName
+	defaultInstance.Labels = map[string]string{
+		InstanceNameLabel: DefaultInstanceName,
+	}
+	err = r.Create(ctx, &defaultInstance)
+	if err != nil {
+		logger.Errorf("creating default isntance failed, the default TriggerInstance may not be created: %s", err)
+		return
+	}
+
+	logger.Infof("default instance %s/%s with labels %v created",
+		defaultInstance.Namespace,
+		defaultInstance.Name,
+		defaultInstance.Labels)
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
Fixes #8 

- [x] Start a default TriggerInstance once controller is deployed, named default (optionally this feature can be disabled)
- [x] TriggerService without selectors automatically uses the default instance
- [x] change label `app: xxx` to `instance: xxx`