### PR TITLE
Fix: creating default instance when it not found in triggerinstance_controller.go

### DIFF
--- a/controllers/triggerinstance/triggerinstance_controller.go
+++ b/controllers/triggerinstance/triggerinstance_controller.go
@@ -146,26 +146,26 @@ func (r *Reconciler) createDefaultInstance(ctx context.Context) {
 	}
 	if util.IgnoreNotFound(err) != nil {
 		logger.Errorf("getting default instance failed, the default TriggerInstance may not be created: %s", err)
-		return
+
+		// Default instance not found, create a default one.
+		// TODO(charlie0129): also check its status and spec, if not right, fix it.
+		defaultInstance.Namespace = DefaultInstanceNamespace
+		defaultInstance.Name = DefaultInstanceName
+		defaultInstance.Labels = map[string]string{
+			InstanceNameLabel: DefaultInstanceName,
+		}
+		err = r.Create(ctx, &defaultInstance)
+		if err != nil {
+			logger.Errorf("creating default isntance failed when it not found: %s", err)
+			return
+		}
+
+		logger.Infof("default instance %s/%s with labels %v created",
+			defaultInstance.Namespace,
+			defaultInstance.Name,
+			defaultInstance.Labels)
 	}
 
-	// Default instance not found, create a default one.
-	// TODO(charlie0129): also check its status and spec, if not right, fix it.
-	defaultInstance.Namespace = DefaultInstanceNamespace
-	defaultInstance.Name = DefaultInstanceName
-	defaultInstance.Labels = map[string]string{
-		InstanceNameLabel: DefaultInstanceName,
-	}
-	err = r.Create(ctx, &defaultInstance)
-	if err != nil {
-		logger.Errorf("creating default isntance failed, the default TriggerInstance may not be created: %s", err)
-		return
-	}
-
-	logger.Infof("default instance %s/%s with labels %v created",
-		defaultInstance.Namespace,
-		defaultInstance.Name,
-		defaultInstance.Labels)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/action/builtin/patchk8sobjects/patch_k8s_objects_test.go
+++ b/pkg/action/builtin/patchk8sobjects/patch_k8s_objects_test.go
@@ -27,7 +27,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 )
 
-var _ = Describe("Test context in patch", func() {
+var _ = Describe("Test context in patch", Ordered, func() {
 	ctx := context.TODO()
 	var props map[string]interface{}
 
@@ -47,6 +47,15 @@ var _ = Describe("Test context in patch", func() {
 		cm.Data = map[string]string{"data": ""}
 		err := k8sClient.Create(ctx, &cm)
 		Expect(util.IgnoreAlreadyExists(err)).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		By("delete test configmaps")
+		cm := v1.ConfigMap{}
+		cm.Namespace = "default"
+		cm.Name = "test-cm"
+		err := k8sClient.Delete(ctx, &cm)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	test := func(patch string, event, data interface{}, expected string) func() {
@@ -99,7 +108,7 @@ var _ = Describe("Test context in patch", func() {
 	))
 })
 
-var _ = Describe("General tests", func() {
+var _ = Describe("General tests", Ordered, func() {
 	ctx := context.TODO()
 	var props map[string]interface{}
 
@@ -132,6 +141,10 @@ var _ = Describe("General tests", func() {
 
 		err = p.Run(ctx, "", nil, nil, nil)
 		Expect(err).To(HaveOccurred())
+
+		By("delete test configmaps")
+		err = k8sClient.Delete(ctx, &cm)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("test patchTarget.name and patchTarget.labelSelectors", func() {
@@ -212,5 +225,12 @@ var _ = Describe("General tests", func() {
 		}, &cm)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cm.Data["data"]).To(Equal("only test-cm-2"))
+
+		By("delete test configmaps")
+		err = k8sClient.Delete(ctx, &cm1)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = k8sClient.Delete(ctx, &cm2)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Fix: creating default instance when it not found in triggerinstance_controller.go
Signed-off-by: liulei <liul24@163.com>