### PR TITLE
Feature/image state update action

### DIFF
--- a/config/definition/image-update-task.yaml
+++ b/config/definition/image-update-task.yaml
@@ -1,0 +1,91 @@
+apiVersion: core.oam.dev/v1alpha1
+kind: Definition
+metadata:
+  name: image-update-task
+  namespace: vela-system
+spec:
+  type: trigger-action
+  templates:
+    # create a Job resource as an action in the same namespace as the source (by default)
+    main.cue: |
+      import (
+        "vela/kube"
+      )
+
+      apply: kube.#Apply & {
+        $params: {
+          resource: {
+            apiVersion: "batch/v1"
+            kind: "Job"
+            metadata: {
+              name: context.data.metadata.name
+              namespace: parameter.namespace
+              if context.data.metadata.labels != _|_ {
+                labels: context.data.metadata.labels
+              }
+              ownerReferences: [
+                {
+                  apiVersion: context.data.apiVersion
+                  kind:       context.data.kind
+                  name:       context.data.metadata.name
+                  uid:        context.data.metadata.uid
+                  controller: true
+                },
+              ]
+            }
+
+            spec: {
+              if parameter.ttlSecondsAfterFinished != _|_ {
+                ttlSecondsAfterFinished: parameter.ttlSecondsAfterFinished
+              }
+
+              template: {
+                spec: {
+                  restartPolicy: parameter.restart
+                  containers: [{
+                    name: context.data.metadata.name
+                    image: parameter.image
+                    command: parameter.cmd
+
+                    env: [{
+                      name: "SOURCE_NAME"
+                      value: context.data.metadata.name
+                    },{
+                      name: "SOURCE_NAMESPACE"
+                      value: context.data.metadata.namespace
+                    },
+                    if parameter.env != _|_ {
+                      parameter.env
+                    }]
+                  }]
+                }
+              }
+            }
+          }
+        }
+      }
+
+      parameter: {
+        // +usage=The image to run the job container on
+        image: string
+
+        // +usage=The namespace to create the Job in
+        namespace: *context.data.metadata.namespace | string
+
+        // +usage=Define the job restart policy, the value can only be Never or OnFailure. By default, it's Never.
+        restart: *"Never" | string
+
+        // +usage=Number of seconds to wait before a successfully completed job is cleaned up
+        ttlSecondsAfterFinished?: uint
+
+        // +usage=Commands to run in the container
+        cmd: [...string]
+
+        // +usage=Define evironment variables for the Job container
+        env?: [...{
+          // +usage=Name of the environment variable
+          name: string
+          // +usage=Value of the environment variable
+          value: string
+        }]
+      }

--- a/config/definition/image-update-task.yaml
+++ b/config/definition/image-update-task.yaml
@@ -47,16 +47,25 @@ spec:
                     image: parameter.image
                     command: parameter.cmd
 
-                    env: [{
-                      name: "SOURCE_NAME"
-                      value: context.data.metadata.name
-                    },{
-                      name: "SOURCE_NAMESPACE"
-                      value: context.data.metadata.namespace
-                    },
+                    if parameter.env == _|_ {
+                      env: [{
+                        name: "SOURCE_NAME"
+                        value: context.data.metadata.name
+                      },{
+                        name: "SOURCE_NAMESPACE"
+                        value: context.data.metadata.namespace
+                      }]
+                    }
+
                     if parameter.env != _|_ {
-                      parameter.env
-                    }]
+                      env: [{
+                        name: "SOURCE_NAME"
+                        value: context.data.metadata.name
+                      },{
+                        name: "SOURCE_NAMESPACE"
+                        value: context.data.metadata.namespace
+                      }] + parameter.env
+                    }
                   }]
                 }
               }

--- a/config/definition/task.yaml
+++ b/config/definition/task.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.oam.dev/v1alpha1
 kind: Definition
 metadata:
-  name: image-update-task
+  name: task
   namespace: vela-system
 spec:
   type: trigger-action
@@ -18,7 +18,7 @@ spec:
             apiVersion: "batch/v1"
             kind: "Job"
             metadata: {
-              name: context.data.metadata.name
+              name: parameter.name
               namespace: parameter.namespace
               if context.data.metadata.labels != _|_ {
                 labels: context.data.metadata.labels
@@ -43,7 +43,7 @@ spec:
                 spec: {
                   restartPolicy: parameter.restart
                   containers: [{
-                    name: context.data.metadata.name
+                    name: parameter.name
                     image: parameter.image
                     command: parameter.cmd
 
@@ -77,6 +77,9 @@ spec:
       parameter: {
         // +usage=The image to run the job container on
         image: string
+
+        // +usage=Name of the cron job
+        name: *context.data.metadata.name | string
 
         // +usage=The namespace to create the Job in
         namespace: *context.data.metadata.namespace | string

--- a/examples/triggerservice-image-update.yaml
+++ b/examples/triggerservice-image-update.yaml
@@ -23,9 +23,6 @@ spec:
         type: image-update-task
         properties:
           cmd: [/bin/sh, -c, "echo Image: ${SOURCE_NAME} in namespace: ${SOURCE_NAMESPACE} has been successfully rebased at $(date)"]
-          env:
-          - name: TEST_KEY
-            value: TEST_VALUE
           image: busybox
           name: image-update-task
           ttlSecondsAfterFinished: 600

--- a/examples/triggerservice-image-update.yaml
+++ b/examples/triggerservice-image-update.yaml
@@ -1,0 +1,31 @@
+apiVersion: standard.oam.dev/v1alpha1
+kind: TriggerService
+metadata:
+  name: image-rebase-trigger
+  namespace: default
+spec:
+  triggers:
+    - source:
+        # source is all the kpack Image resources in all the namespaces
+        type: resource-watcher
+        properties:
+          apiVersion: kpack.io/v1alpha2
+          # kpack needs to be installed on the cluster to have this resource type
+          kind: Image
+          events:
+            - update
+
+      # only trigger action when an Image is successfully rebased
+      filter: >
+        context.data.status.latestBuildReason == "STACK" && context.data.status.conditions[0].status == "True"
+      
+      action:
+        type: image-update-task
+        properties:
+          cmd: [/bin/sh, -c, "echo Image: ${SOURCE_NAME} in namespace: ${SOURCE_NAMESPACE} has been successfully rebased at $(date)"]
+          env:
+          - name: TEST_KEY
+            value: TEST_VALUE
+          image: busybox
+          name: image-update-task
+          ttlSecondsAfterFinished: 600

--- a/examples/triggerservice-image-update.yaml
+++ b/examples/triggerservice-image-update.yaml
@@ -20,7 +20,7 @@ spec:
         context.data.status.latestBuildReason == "STACK" && context.data.status.conditions[0].status == "True"
       
       action:
-        type: image-update-task
+        type: task
         properties:
           cmd: [/bin/sh, -c, "echo Image: ${SOURCE_NAME} in namespace: ${SOURCE_NAMESPACE} has been successfully rebased at $(date)"]
           image: busybox


### PR DESCRIPTION
### Description of your changes

Adds `trigger-action` definition and a corresponding `TriggerSerivce` example.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] Add related tests.
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

After applying the `trigger-action` definition and the `TriggerService` example, respectively, the TriggerService will monitor all the [kpack](https://github.com/pivotal/kpack) `Image` type resources on the cluster and deploy a `Job` as an action when any `Image` is successfully rebased. The Job's pod will log the name and the namespace of the source `Image` that triggered the action.


### Special notes for your reviewer

The definition can be applied without any issues but creating the TriggerService would fail if `kpack` is not installed on the cluster.