### PR TITLE
Chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-*  @FogDong @charlie0129 @Somefive
+*  @FogDong @charlie0129 @Somefive @anoop2811 @briankane @jguionnet


### PR DESCRIPTION
### Description of your changes

Adds @anoop2811, @briankane and @jguionnet as CODEOWNERS

Issues #
https://github.com/kubevela/community/issues/248
https://github.com/kubevela/community/issues/247

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
- [x] Add related tests.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add @anoop2811, @briankane, and @jguionnet to CODEOWNERS for the whole repo. This fulfills kubevela/community #247 and #248 so the correct maintainers are auto-assigned to reviews.

<!-- End of auto-generated description by cubic. -->

